### PR TITLE
Fix bug in toyaml

### DIFF
--- a/tojson.hpp
+++ b/tojson.hpp
@@ -121,7 +121,11 @@ inline void toyaml(const nlohmann::json &j, YAML::Emitter &e) {
 			if (it.key() == "@text") {
 				e << YAML::Value << it.value().get<std::string>();
 			} else {
-				e << YAML::Key << it.key() << YAML::Value << it.value().get<std::string>();
+				e << YAML::Key << it.key() << YAML::Value;
+				if (it->type() == nlohmann::json::value_t::string)
+					e << it.value().get<std::string>();
+				else
+					e << it->dump();
 			}
 		}
 	}


### PR DESCRIPTION
where converting a json object containing numeric values to yaml caused an exception because of obtaining a numeric value as string